### PR TITLE
bug fix when iterators stops at multiple of batch_size

### DIFF
--- a/tensorflow/contrib/learn/python/learn/graph_actions.py
+++ b/tensorflow/contrib/learn/python/learn/graph_actions.py
@@ -285,8 +285,13 @@ def _monitored_train(graph,
         hooks=all_hooks) as super_sess:
       loss = None
       while not super_sess.should_stop():
-        _, loss = super_sess.run([train_op, loss_op], feed_fn() if feed_fn else
-                                 None)
+        feed_dict = feed_fn() if feed_fn else None
+        # check for case when iterator stopped exactly at multiple of batch_size
+        # In such case, all the returned numpy array are len zero.
+        edge_condition = True if feed_dict and all(len(v) == 0 for v in feed_dict.values()) else False
+        if not edge_condition:
+          _, loss = super_sess.run([train_op, loss_op], feed_dict)
+          
       return loss
 
 


### PR DESCRIPTION
I get NanLossDuringTrainingError when I run the following snippet. In the following gist file link, I have also pasted detailed error description
- [Gist Link](https://gist.github.com/abhitopia/b6b60cb8bf9bab58a78b221fb3c4473b)
- [Discussion about the issue of google groups](https://groups.google.com/a/tensorflow.org/forum/#!topic/discuss/ZEzEa1TyYuE)

The problem is caused by how edge case is handled in graph_actions.py , a simple patch fixes the problem.
